### PR TITLE
Improve Observer and Observable classes implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,27 @@
-sudo: required
-
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-  - sudo apt-get install libboost-all-dev
+sudo: false
 
 language: cpp
+
+cache:
+  apt: true
+
+addons:
+  apt:
+    sources:
+    - boost-latest
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - libboost-system1.54-dev
+    - libboost-thread1.54-dev
 
 compiler:
   - clang
   - gcc
+
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 script:
   - mkdir build

--- a/include/base/iobservable.h
+++ b/include/base/iobservable.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 namespace skylog {
+namespace base {
 
 template <typename ObserverType>
 class IObservable {
@@ -41,4 +42,5 @@ class IObservable {
   virtual void NotifyObservers(const ObserverMessage& message) = 0;
 };
 
+}  // namespace base
 }  // namespace skylog

--- a/include/base/iobserver.h
+++ b/include/base/iobserver.h
@@ -23,6 +23,7 @@
 #pragma once
 
 namespace skylog {
+namespace base {
 
 template <typename ObserverMessageType>
 class IObserver {
@@ -34,4 +35,5 @@ class IObserver {
   virtual void Notify(const ObserverMessage& message) = 0;
 };
 
+}  // namespace base
 }  // namespace skylog

--- a/include/base/observer.h
+++ b/include/base/observer.h
@@ -22,15 +22,15 @@
 
 #pragma once
 
-#include <string>
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
 
-#include "core/iobserver.h"
+#include "base/iobserver.h"
 
 namespace skylog {
+namespace base {
 
 template <typename ObserverMessageType>
 class Observer : public IObserver<ObserverMessageType> {
@@ -63,7 +63,7 @@ class Observer : public IObserver<ObserverMessageType> {
   Observer(Observer&&) = default;
   Observer& operator=(Observer&&) = default;
 
-  void Notify(const ObserverMessage& message) override {
+  void Notify(const ObserverMessage& message) final {
     service_.post(boost::bind(
                       &Handler::Handle, handler_, message));
   }
@@ -75,4 +75,5 @@ class Observer : public IObserver<ObserverMessageType> {
   Handler* handler_;
 };
 
+}  // namespace base
 }  // namespace skylog

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,6 +20,19 @@
  * SOFTWARE.
  */
 
+#include <memory>
+#include <string>
+
+#include "base/observer.h"
+#include "base/observable.h"
+
 int main() {
+  std::shared_ptr<skylog::base::IObserver<std::string> > observer =
+      std::make_shared<skylog::base::Observer<std::string> >(nullptr);
+  std::shared_ptr<skylog::base::IObservable<skylog::base::IObserver<std::string> > > observable =
+      std::make_shared<skylog::base::Observable<skylog::base::IObserver<std::string> > >();
+  observable->AddObserver("observer", observer);
+  observable->NotifyObservers("message");
+
   return 0;
 }


### PR DESCRIPTION
* Move `Observer` and `Observable` classes into new `base` namespace
* Remove redundant `boost` usage from `Observable`
* Add simple example to `main()` function