### PR TITLE
Stop Observer before appender destruction

### DIFF
--- a/src/appender/console_appender.cc
+++ b/src/appender/console_appender.cc
@@ -31,7 +31,9 @@
 skylog::appender::ConsoleAppender::ConsoleAppender()
     : base::Observer<AppenderMessage>(this) {}
 
-skylog::appender::ConsoleAppender::~ConsoleAppender() {}
+skylog::appender::ConsoleAppender::~ConsoleAppender() {
+  base::Observer<AppenderMessage>::Stop();
+}
 
 void skylog::appender::ConsoleAppender::Handle(const AppenderMessage& message) {
   const std::time_t time_stamp =

--- a/src/appender/file_appender.cc
+++ b/src/appender/file_appender.cc
@@ -31,7 +31,9 @@
 skylog::appender::FileAppender::FileAppender(const std::string& file_path)
     : base::Observer<AppenderMessage>(this), file_stream_(file_path) {}
 
-skylog::appender::FileAppender::~FileAppender() {}
+skylog::appender::FileAppender::~FileAppender() {
+  base::Observer<AppenderMessage>::Stop();
+}
 
 void skylog::appender::FileAppender::Handle(const AppenderMessage& message) {
   if (!file_stream_.is_open()) {


### PR DESCRIPTION
* Add `Stop()` method to `Observer` that prevents new messages adding and waits for present messages  are processed
* Call `Observer::Stop()` method in appenders destructors
* Replace `boost::scoped_ptr` with `std::unique_ptr` in `Observer`