### PR TITLE
Replace shared ptr with unique ptr in Observable implementation

### DIFF
--- a/include/base/iobservable.h
+++ b/include/base/iobservable.h
@@ -32,12 +32,12 @@ template <typename ObserverType>
 class IObservable {
  public:
   using ObserverMessage = typename ObserverType::ObserverMessage;
-  using ObserverPointer = std::shared_ptr<ObserverType>;
+  using ObserverPointer = std::unique_ptr<ObserverType>;
 
   virtual ~IObservable() {}
 
   virtual bool AddObserver(const std::string& name,
-                           ObserverPointer observer) = 0;
+                           ObserverPointer&& observer) = 0;
   virtual void RemoveObserver(const std::string& name) = 0;
   virtual void NotifyObservers(const ObserverMessage& message) = 0;
 };

--- a/include/base/observable.h
+++ b/include/base/observable.h
@@ -42,9 +42,9 @@ class Observable : public IObservable<ObserverType> {
   Observable(Observable&&) = default;
   Observable& operator=(Observable&&) = default;
 
-  bool AddObserver(const std::string& name, ObserverPointer observer) final {
+  bool AddObserver(const std::string& name, ObserverPointer&& observer) final {
     std::unique_lock<std::mutex> lock(observers_map_mutex_);
-    return observers_map_.emplace(name, observer).second;
+    return observers_map_.emplace(name, std::move(observer)).second;
   }
   void RemoveObserver(const std::string& name) final {
     std::unique_lock<std::mutex> lock(observers_map_mutex_);

--- a/src/main.cc
+++ b/src/main.cc
@@ -24,24 +24,25 @@
 #include <string>
 #include <chrono>
 
-#include "base/observable.h"
 #include "message/log_message.h"
+#include "base/observable.h"
 #include "appender/file_appender.h"
 #include "appender/console_appender.h"
 
 int main() {
-  std::shared_ptr<skylog::base::IObserver<skylog::message::LogMessage> >
-      file_appender =
-          std::make_shared<skylog::appender::FileAppender>("test_file.txt");
-  std::shared_ptr<skylog::base::IObserver<skylog::message::LogMessage> >
-      console_appender = std::make_shared<skylog::appender::ConsoleAppender>();
-
   std::shared_ptr<skylog::base::IObservable<
       skylog::base::IObserver<skylog::message::LogMessage> > > observable =
       std::make_shared<skylog::base::Observable<
           skylog::base::IObserver<skylog::message::LogMessage> > >();
-  observable->AddObserver("FileAppender", file_appender);
-  observable->AddObserver("ConsoleAppender", console_appender);
+
+  observable->AddObserver(
+      "FileAppender",
+      std::unique_ptr<skylog::base::IObserver<skylog::message::LogMessage> >(
+          new skylog::appender::FileAppender("test_file.txt")));
+  observable->AddObserver(
+      "ConsoleAppender",
+      std::unique_ptr<skylog::base::IObserver<skylog::message::LogMessage> >(
+          new skylog::appender::ConsoleAppender()));
 
   observable->NotifyObservers(
       skylog::message::LogMessage(skylog::message::LogLevel::LL_DEBUG,


### PR DESCRIPTION
* Use `std::unique_ptr` instead of `std::shared_ptr` in `Observable`
* Update `main.cc` example to create `std::unique_ptr` instead of `std::shared_ptr`