### PR TITLE
Use shared pointers for messages

### DIFF
--- a/include/appender/console_appender.h
+++ b/include/appender/console_appender.h
@@ -31,8 +31,9 @@ namespace appender {
 class ConsoleAppender : public base::Observer<message::LogMessage>,
                         public base::Observer<message::LogMessage>::Handler {
  public:
-  using AppenderMessage =
-      typename base::Observer<message::LogMessage>::ObserverMessage;
+  using BaseObserver = base::Observer<message::LogMessage>;
+  using AppenderMessagePointer =
+      typename base::Observer<message::LogMessage>::ObserverMessagePointer;
 
   ConsoleAppender();
   ~ConsoleAppender();
@@ -41,7 +42,7 @@ class ConsoleAppender : public base::Observer<message::LogMessage>,
   ConsoleAppender& operator=(ConsoleAppender&&) = default;
 
  private:
-  void Handle(const AppenderMessage& message) final;
+  void Handle(const AppenderMessagePointer& message) final;
 };
 
 }  // namespace appender

--- a/include/appender/file_appender.h
+++ b/include/appender/file_appender.h
@@ -34,8 +34,9 @@ namespace appender {
 class FileAppender : public base::Observer<message::LogMessage>,
                      public base::Observer<message::LogMessage>::Handler {
  public:
-  using AppenderMessage =
-      typename base::Observer<message::LogMessage>::ObserverMessage;
+  using BaseObserver = base::Observer<message::LogMessage>;
+  using AppenderMessagePointer =
+      typename base::Observer<message::LogMessage>::ObserverMessagePointer;
 
   explicit FileAppender(const std::string& file_path);
   ~FileAppender();
@@ -44,7 +45,7 @@ class FileAppender : public base::Observer<message::LogMessage>,
   FileAppender& operator=(FileAppender&&) = default;
 
  private:
-  void Handle(const AppenderMessage& message) final;
+  void Handle(const AppenderMessagePointer& message) final;
 
   std::ofstream file_stream_;
 };

--- a/include/base/iobservable.h
+++ b/include/base/iobservable.h
@@ -31,7 +31,7 @@ namespace base {
 template <typename ObserverType>
 class IObservable {
  public:
-  using ObserverMessage = typename ObserverType::ObserverMessage;
+  using ObserverMessagePointer = typename ObserverType::ObserverMessagePointer;
   using ObserverPointer = std::unique_ptr<ObserverType>;
 
   virtual ~IObservable() {}
@@ -39,7 +39,7 @@ class IObservable {
   virtual bool AddObserver(const std::string& name,
                            ObserverPointer&& observer) = 0;
   virtual void RemoveObserver(const std::string& name) = 0;
-  virtual void NotifyObservers(const ObserverMessage& message) = 0;
+  virtual void NotifyObservers(const ObserverMessagePointer& message) = 0;
 };
 
 }  // namespace base

--- a/include/base/iobserver.h
+++ b/include/base/iobserver.h
@@ -22,17 +22,19 @@
 
 #pragma once
 
+#include <memory>
+
 namespace skylog {
 namespace base {
 
 template <typename ObserverMessageType>
 class IObserver {
  public:
-  using ObserverMessage = ObserverMessageType;
+  using ObserverMessagePointer = std::shared_ptr<ObserverMessageType>;
 
   virtual ~IObserver() {}
 
-  virtual void Notify(const ObserverMessage& message) = 0;
+  virtual void Notify(const ObserverMessagePointer& message) = 0;
 };
 
 }  // namespace base

--- a/include/base/observable.h
+++ b/include/base/observable.h
@@ -34,7 +34,8 @@ namespace base {
 template <typename ObserverType>
 class Observable : public IObservable<ObserverType> {
  public:
-  using ObserverMessage = typename IObservable<ObserverType>::ObserverMessage;
+  using ObserverMessagePointer =
+      typename IObservable<ObserverType>::ObserverMessagePointer;
   using ObserverPointer = typename IObservable<ObserverType>::ObserverPointer;
 
   Observable() = default;
@@ -50,7 +51,7 @@ class Observable : public IObservable<ObserverType> {
     std::unique_lock<std::mutex> lock(observers_map_mutex_);
     observers_map_.erase(name);
   }
-  void NotifyObservers(const ObserverMessage& message) final {
+  void NotifyObservers(const ObserverMessagePointer& message) final {
     std::unique_lock<std::mutex> lock(observers_map_mutex_);
     for (auto& kv : observers_map_) {
       kv.second->Notify(message);

--- a/include/base/observer.h
+++ b/include/base/observer.h
@@ -37,14 +37,14 @@ namespace base {
 template <typename ObserverMessageType>
 class Observer : public IObserver<ObserverMessageType> {
  public:
-  using ObserverMessage =
-      typename IObserver<ObserverMessageType>::ObserverMessage;
+  using ObserverMessagePointer =
+      typename IObserver<ObserverMessageType>::ObserverMessagePointer;
 
   class Handler {
    public:
     virtual ~Handler() {}
 
-    virtual void Handle(const ObserverMessage& message) = 0;
+    virtual void Handle(const ObserverMessagePointer& message) = 0;
   };
 
   explicit Observer(Handler* handler)
@@ -61,7 +61,7 @@ class Observer : public IObserver<ObserverMessageType> {
   Observer(Observer&&) = default;
   Observer& operator=(Observer&&) = default;
 
-  void Notify(const ObserverMessage& message) final {
+  void Notify(const ObserverMessagePointer& message) final {
     if (is_running_) {
       service_.post(boost::bind(&Handler::Handle, handler_, message));
     }

--- a/src/appender/console_appender.cc
+++ b/src/appender/console_appender.cc
@@ -28,25 +28,25 @@
 
 #include "base/observer.h"
 
-skylog::appender::ConsoleAppender::ConsoleAppender()
-    : base::Observer<AppenderMessage>(this) {}
+skylog::appender::ConsoleAppender::ConsoleAppender() : BaseObserver(this) {}
 
 skylog::appender::ConsoleAppender::~ConsoleAppender() {
-  base::Observer<AppenderMessage>::Stop();
+  BaseObserver::Stop();
 }
 
-void skylog::appender::ConsoleAppender::Handle(const AppenderMessage& message) {
+void skylog::appender::ConsoleAppender::Handle(
+    const AppenderMessagePointer& message) {
   const std::time_t time_stamp =
-      std::chrono::system_clock::to_time_t(message.time());
+      std::chrono::system_clock::to_time_t(message->time());
   const std::size_t time_buffer_size = 50;
   char time_buffer[time_buffer_size];
   std::strftime(
       time_buffer, time_buffer_size, "%x %X", std::localtime(&time_stamp));
 
-  std::cout << message.level_string() << " [" << time_buffer << "] ["
-            << "0x" << std::hex << message.thread_id() << "] "
-            << message.file_name() << " " << message.function_name()
-            << "::" << std::dec << message.line_number() << ": "
-            << message.log_string() << "\n";
+  std::cout << message->level_string() << " [" << time_buffer << "] ["
+            << "0x" << std::hex << message->thread_id() << "] "
+            << message->file_name() << " " << message->function_name()
+            << "::" << std::dec << message->line_number() << ": "
+            << message->log_string() << "\n";
   std::cout << std::flush;
 }

--- a/src/appender/file_appender.cc
+++ b/src/appender/file_appender.cc
@@ -29,28 +29,29 @@
 #include "base/observer.h"
 
 skylog::appender::FileAppender::FileAppender(const std::string& file_path)
-    : base::Observer<AppenderMessage>(this), file_stream_(file_path) {}
+    : BaseObserver(this), file_stream_(file_path) {}
 
 skylog::appender::FileAppender::~FileAppender() {
-  base::Observer<AppenderMessage>::Stop();
+  BaseObserver::Stop();
 }
 
-void skylog::appender::FileAppender::Handle(const AppenderMessage& message) {
+void skylog::appender::FileAppender::Handle(
+    const AppenderMessagePointer& message) {
   if (!file_stream_.is_open()) {
     return;
   }
 
   const std::time_t time_stamp =
-      std::chrono::system_clock::to_time_t(message.time());
+      std::chrono::system_clock::to_time_t(message->time());
   const std::size_t time_buffer_size = 50;
   char time_buffer[time_buffer_size];
   std::strftime(
       time_buffer, time_buffer_size, "%x %X", std::localtime(&time_stamp));
 
-  file_stream_ << message.level_string() << " [" << time_buffer << "] ["
-               << "0x" << std::hex << message.thread_id() << "] "
-               << message.file_name() << " " << message.function_name()
-               << "::" << std::dec << message.line_number() << ": "
-               << message.log_string() << "\n";
+  file_stream_ << message->level_string() << " [" << time_buffer << "] ["
+               << "0x" << std::hex << message->thread_id() << "] "
+               << message->file_name() << " " << message->function_name()
+               << "::" << std::dec << message->line_number() << ": "
+               << message->log_string() << "\n";
   file_stream_.flush();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -44,14 +44,14 @@ int main() {
       std::unique_ptr<skylog::base::IObserver<skylog::message::LogMessage> >(
           new skylog::appender::ConsoleAppender()));
 
-  observable->NotifyObservers(
-      skylog::message::LogMessage(skylog::message::LogLevel::LL_DEBUG,
-                                  std::chrono::system_clock::now(),
-                                  13,
-                                  "test_file.cc",
-                                  "TestFunction",
-                                  167,
-                                  "Hello, world!!!"));
+  observable->NotifyObservers(std::make_shared<skylog::message::LogMessage>(
+      skylog::message::LogLevel::LL_DEBUG,
+      std::chrono::system_clock::now(),
+      13,
+      "test_file.cc",
+      "TestFunction",
+      167,
+      "Hello, world!!!"));
 
   return 0;
 }


### PR DESCRIPTION
Currently we're copying each message to each appender's message loop. To avoid redundant messages copying we can use shared pointers for message access from different appenders. Message will be destroyed only after being processed by all appenders.